### PR TITLE
Added test for failing code

### DIFF
--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 require File.expand_path("../common", __FILE__)
+require 'rubygems'
+require 'active_support'
 
 class HTMLEntities::EncodingTest < Test::Unit::TestCase
 
@@ -11,6 +13,11 @@ class HTMLEntities::EncodingTest < Test::Unit::TestCase
     @entities.each do |coder|
       assert_equal expected, coder.encode(input, *args)
     end
+  end
+
+  def test_failing_encode
+    string = ActiveSupport::SafeBuffer.new("<p>This is a test</p>")
+    assert_equal HTMLEntities.new.encode(string, :named), "&lt;p&gt;This is a test&lt;/p&gt;"
   end
 
   def test_should_encode_basic_entities


### PR DESCRIPTION
I added a failing test. This depends on that ActiveSupport with version 3+, I use 3.0.9, is installed. If you want this patch you might want to add that to the gemspec.

The culprit is ActiveSupport::SafeBuffer, which is added when our code uses sanitize from ActionView::Helpers::SanitizeHelper.
