### PR TITLE
Decode entities without semicolon when permissible

### DIFF
--- a/lib/htmlentities/decoder.rb
+++ b/lib/htmlentities/decoder.rb
@@ -32,7 +32,7 @@ class HTMLEntities
       else
         entity_name_pattern = '[a-z][a-z0-9]'
       end
-      /&(?:(#{entity_name_pattern}{#{key_lengths.min - 1},#{key_lengths.max - 1}})|#([0-9]{1,7})|#x([0-9a-f]{1,6}));/i
+      /&(?:(#{entity_name_pattern}{#{key_lengths.min - 1},#{key_lengths.max - 1}})|#([0-9]{1,7})|#x([0-9a-f]{1,6}))(;|(?=\n|<))/i
     end
   end
 end

--- a/test/decoding_test.rb
+++ b/test/decoding_test.rb
@@ -98,4 +98,14 @@ class HTMLEntities::DecodingTest < Test::Unit::TestCase
     assert_decode "foo", obj
   end
 
+  def test_should_decode_without_semicolon_if_persmissible
+    assert_decode "&\n\n\n", "&amp;\n\n\n"
+    assert_decode '&<tag>', '&amp<tag>'
+  end
+
+  def test_should_skip_without_semicolon
+    assert_decode '&amp', '&amp'
+    assert_decode '&ampsome text', '&ampsome text'
+  end
+
 end


### PR DESCRIPTION
I quite often run into deprecated html entities that don't contain trailing semicolon. I'm attaching a pr with respect to [HTML 4 specification regarding character references](https://www.w3.org/TR/html4/charset.html#h-5.3):

> Note. In SGML, it is possible to eliminate the final ";" after a character reference in some cases (e.g., at a line break or immediately before a tag). In other circumstances it may not be eliminated (e.g., in the middle of a word). We strongly suggest using the ";" in all cases to avoid problems with user agents that require this character to be present.

That is an entity would be decoded only if immediately followed by a newline character or an opening angle bracket.