### PR TITLE
Add encoder instruction to restrict encoding to four-byte characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,43 +35,49 @@ to carry out.
 ```ruby
 require 'htmlentities'
 coder = HTMLEntities.new
-string = "<élan>"
+string = "<élan>🤠"
 ```
 
 Escape unsafe codepoints only:
 
 ```ruby
-coder.encode(string) # => "&lt;élan&gt;"
+coder.encode(string) # => "&lt;élan&gt;🤠"
 ```
 
 Or:
 
 ```ruby
-coder.encode(string, :basic) # => "&lt;élan&gt;"
+coder.encode(string, :basic) # => "&lt;élan&gt;🤠"
 ```
 
 Escape all entities that have names:
 
 ```ruby
-coder.encode(string, :named) # => "&lt;&eacute;lan&gt;"
+coder.encode(string, :named) # => "&lt;&eacute;lan&gt;🤠"
 ```
 
 Escape all non-ASCII/non-safe codepoints using decimal entities:
 
 ```ruby
-coder.encode(string, :decimal) # => "&#60;&#233;lan&#62;"
+coder.encode(string, :decimal) # => "&#60;&#233;lan&#62;&#129312;"
 ```
 
 As above, using hexadecimal entities:
 
 ```ruby
-coder.encode(string, :hexadecimal) # => "&#x3c;&#xe9;lan&#x3e;"
+coder.encode(string, :hexadecimal) # => "&#x3c;&#xe9;lan&#x3e;&#x1f920;"
 ```
 
 You can also use several options, e.g. use named entities for unsafe codepoints, then decimal for all other non-ASCII:
 
 ```ruby
-coder.encode(string, :basic, :decimal) # => "&lt;&#233;lan&gt;"
+coder.encode(string, :basic, :decimal) # => "&lt;&#233;lan&gt;&#129312;"
+```
+
+You can also restrict encoding to four-byte characters (like emojis):
+
+```ruby
+coder.encode(string, :hexadecimal, :four_byte) # => "<élan>&#x1f920;"
 ```
 
 ### Flavours

--- a/lib/htmlentities.rb
+++ b/lib/htmlentities.rb
@@ -52,6 +52,7 @@ class HTMLEntities
   # :named :: Convert non-ASCII characters to their named HTML 4.01 equivalent
   # :decimal :: Convert non-ASCII characters to decimal entities (e.g. &#1234;)
   # :hexadecimal :: Convert non-ASCII characters to hexadecimal entities (e.g. # &#x12ab;)
+  # :four_byte :: Convert four-byte characters
   #
   # You can specify the commands in any order, but they will be executed in
   # the order listed above to ensure that entity ampersands are not

--- a/lib/htmlentities/encoder.rb
+++ b/lib/htmlentities/encoder.rb
@@ -2,7 +2,7 @@ class HTMLEntities
   InstructionError = Class.new(RuntimeError)
 
   class Encoder #:nodoc:
-    INSTRUCTIONS = [:basic, :named, :decimal, :hexadecimal]
+    INSTRUCTIONS = [:basic, :named, :decimal, :hexadecimal, :four_byte]
 
     def initialize(flavor, instructions)
       @flavor = flavor
@@ -50,11 +50,23 @@ class HTMLEntities
     end
 
     def replace_basic(string)
-      string.gsub(basic_entity_regexp){ |match| encode_basic(match) }
+      string.gsub(basic_entity_regexp) do |match|
+        if @instructions.include?(:four_byte) && match.bytes.length != 4
+          match
+        else
+          encode_basic(match)
+        end
+      end
     end
 
     def replace_extended(string)
-      string.gsub(extended_entity_regexp){ |match| encode_extended(match) }
+      string.gsub(extended_entity_regexp) do |match|
+        if @instructions.include?(:four_byte) && match.bytes.length != 4
+          match
+        else
+          encode_extended(match)
+        end
+      end
     end
 
     def validate_instructions

--- a/lib/htmlentities/encoder.rb
+++ b/lib/htmlentities/encoder.rb
@@ -6,10 +6,10 @@ class HTMLEntities
 
     def initialize(flavor, instructions)
       @flavor = flavor
-      instructions = [:basic] if instructions.empty?
-      validate_instructions instructions
-      build_basic_entity_encoder instructions
-      build_extended_entity_encoder instructions
+      @instructions = instructions.empty? ? [:basic] : instructions
+      validate_instructions
+      build_basic_entity_encoder
+      build_extended_entity_encoder
     end
 
     def encode(source)
@@ -57,25 +57,25 @@ class HTMLEntities
       string.gsub(extended_entity_regexp){ |match| encode_extended(match) }
     end
 
-    def validate_instructions(instructions)
-      unknown_instructions = instructions - INSTRUCTIONS
+    def validate_instructions
+      unknown_instructions = @instructions - INSTRUCTIONS
       if unknown_instructions.any?
         raise InstructionError,
           "unknown encode_entities command(s): #{unknown_instructions.inspect}"
       end
 
-      if instructions.include?(:decimal) && instructions.include?(:hexadecimal)
+      if @instructions.include?(:decimal) && @instructions.include?(:hexadecimal)
         raise InstructionError,
           "hexadecimal and decimal encoding are mutually exclusive"
       end
     end
 
-    def build_basic_entity_encoder(instructions)
-      if instructions.include?(:basic) || instructions.include?(:named)
+    def build_basic_entity_encoder
+      if @instructions.include?(:basic) || @instructions.include?(:named)
         method = :encode_named
-      elsif instructions.include?(:decimal)
+      elsif @instructions.include?(:decimal)
         method = :encode_decimal
-      elsif instructions.include?(:hexadecimal)
+      elsif @instructions.include?(:hexadecimal)
         method = :encode_hexadecimal
       end
       instance_eval <<-END
@@ -85,8 +85,8 @@ class HTMLEntities
       END
     end
 
-    def build_extended_entity_encoder(instructions)
-      operations = [:named, :decimal, :hexadecimal] & instructions
+    def build_extended_entity_encoder
+      operations = [:named, :decimal, :hexadecimal] & @instructions
       instance_eval <<-END
         def encode_extended(char)
           #{operations.map{ |encoder| %{

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -53,6 +53,11 @@ class HTMLEntities::EncodingTest < Test::Unit::TestCase
     assert_encode '&#x2014;', '—', :hexadecimal
   end
 
+  def test_should_limit_encoding_to_four_byte_characters
+    assert_encode '−', '−', :hexadecimal, :four_byte
+    assert_encode '&#x1f32f;', '🌯', :hexadecimal, :four_byte
+  end
+
   def test_should_encode_text_using_mix_of_entities
     assert_encode(
       '&quot;bient&ocirc;t&quot; &amp; &#x6587;&#x5b57;',


### PR DESCRIPTION
This adds the ability for users to only encode four-byte characters in a given string.

The motivation for adding this feature came from the fact that [MySQL's `utf8` character set](https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8.html) doesn't include four-byte characters, so it would be useful to be able to encode just those characters before trying to persist them to a MySQL database.