### PR TITLE
Add option to tolerate capitalization mistakes

### DIFF
--- a/lib/htmlentities.rb
+++ b/lib/htmlentities.rb
@@ -40,8 +40,13 @@ class HTMLEntities
   #
   # Unknown named entities will not be converted
   #
-  def decode(source)
-    (@decoder ||= Decoder.new(@flavor)).decode(source)
+  def decode(source, tolerate_capitalization_mistakes: false)
+    @decoder ||= Decoder.new(@flavor)
+
+    @decoder.decode(
+      source,
+      tolerate_capitalization_mistakes: tolerate_capitalization_mistakes
+    )
   end
 
   #

--- a/lib/htmlentities/decoder.rb
+++ b/lib/htmlentities/decoder.rb
@@ -6,9 +6,9 @@ class HTMLEntities
       @entity_regexp = entity_regexp
     end
 
-    def decode(source)
+    def decode(source, tolerate_capitalization_mistakes: false)
       prepare(source).gsub(@entity_regexp){
-        if $1 && codepoint = @map[$1]
+        if $1 && codepoint = lookup_mapping($1, case_insensitive: tolerate_capitalization_mistakes)
           codepoint.chr(Encoding::UTF_8)
         elsif $2
           $2.to_i(10).chr(Encoding::UTF_8)
@@ -21,6 +21,17 @@ class HTMLEntities
     end
 
   private
+
+    def lookup_mapping(entity, case_insensitive:)
+      @map.fetch(entity) do
+        if case_insensitive
+          @map[entity.downcase]
+        else
+          nil
+        end
+      end
+    end
+
     def prepare(string) #:nodoc:
       string.to_s.encode(Encoding::UTF_8)
     end


### PR DESCRIPTION
Add an option (defaults to off) which allows decoding to be done in a way that's flexible to capitalization mistakes.

If the correct capitalization exists, it'll be used. Otherwise if this option is on, we will attempt to decode the entity as if it were all lower case.

e.g.

```ruby
HTMLEntities.new.decode('&#oelig;') # => 'œ'
HTMLEntities.new.decode('&#OElig;') # => 'Œ'
HTMLEntities.new.decode('&#OELIG;') # => '&#OELIG;',  this isn't a valid HTML entity, so it's ignored.

HTMLEntities.new.decode('&#oelig;', tolerate_capitalization_mistakes: true) # => 'œ'
HTMLEntities.new.decode('&#OElig;', tolerate_capitalization_mistakes: true) # => 'Œ'
HTMLEntities.new.decode('&#OELIG;', tolerate_capitalization_mistakes: true) # => 'œ', this is best-effort
```

Fixes #35